### PR TITLE
Documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2015 Chris Vogt https://www.chrisvogt.me
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,21 +10,25 @@ Powered by data from the NCES [Digest of Education Statistics](https://nces.ed.g
 
 View live @ [teachersalary.info](http://teachersalary.info).
 
-### Screenshot
+## Screenshot
 
 [![Teacher Salaries: 1969 to 2013](/public/images/screenshot.jpg)](http://teachersalary.info)
 
-### License
+## License
 
 [MIT](LICENSE) © [Chris Vogt](https://www.chrisvogt.me).
 
-### Built with
+## Thanks
+
+[<img src="https://www.browserstack.com/images/mail/browserstack-logo-footer.png" width="120">](https://www.browserstack.com/)
+
+Thank you to [BrowserStack](https://www.browserstack.com/) for providing the infrastructure that allows me to test this project in real browsers.
+
+## Built with
 
 <p align="left">
   <img alt="Node.js" src="https://nodejs.org/static/images/logo-light.svg" height="48">
+  <img src="https://webpack.js.org/assets/icon-square-big.svg" alt="Webpack" height="48">
 	<img src="https://cdn.rawgit.com/facebook/react/455d2d1b48e5cdaeac5d0b4fd92b29b4d52bcaec/docs/img/logo_small_2x.png" alt="React" height="48">
-  <img src="https://cdn.rawgit.com/gulpjs/artwork/master/gulp-2x.png" alt="Gulp" height="48">
-	<img src="https://bower.io/img/bower-logo.svg" alt="Bower.js" height="48">
 	<img src="https://upload.wikimedia.org/wikipedia/commons/1/10/CSS3_and_HTML5_logos_and_wordmarks.svg" alt="HTML5 &amp; CSS3" height="48">
-	<img src="https://cdn.rawgit.com/zurb/foundation-sites/develop/docs/assets/img/yeti.svg" alt="Zurb Foundation" height="48">
 </p>


### PR DESCRIPTION
* Adds back the LICENSE file, which went missing in the 0.9.0 release this AM.
* Adds a thank you to BrowserStack so that I can use their product for _free_ to test this on real devices.
* Corrects the displayed tech in the "built with" section of the project README.