### PR TITLE
Allow word breaks in the "source" content area

### DIFF
--- a/src/styles/Page.css
+++ b/src/styles/Page.css
@@ -12,6 +12,7 @@ h1 {
   margin-top: 0;
   font-size: .875em;
   padding: 0 0 12px;
+  word-wrap: break-word;
 }
 
 .subhead {


### PR DESCRIPTION
This resolves #15.