### PR TITLE
Defines a comma for the thousands separator in the chart tooltip

### DIFF
--- a/src/components/Visualization/initHighcharts.js
+++ b/src/components/Visualization/initHighcharts.js
@@ -8,6 +8,11 @@ function initHighcharts () {
   if (!hasBeenInitialized) {
     highchartsMore(ReactHighcharts.Highcharts)
     highchartsExporting(ReactHighcharts.Highcharts)
+    ReactHighcharts.Highcharts.setOptions({
+      lang: {
+        thousandsSep: ','
+      }
+    })
     hasBeenInitialized = true
   }
 }


### PR DESCRIPTION
Resolves #17.