### PR TITLE
feat: add GH workflow to auto-publish to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: test # This ensures the CI workflow completes first
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # This ensures we get the full git history for the commit hash
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install dependencies with Yarn
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Create CNAME file
+        run: echo "teachersalary.info" > build/CNAME
+
+      - name: Get package version
+        id: package-version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          commit_message: "deploy: ${{ github.sha }} (${{ steps.package-version.outputs.version }}) via GitHub Pages" 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teacher-salaries",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "homepage": "https://teachersalary.info/",
   "private": true,


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying the project to GitHub Pages and includes a version bump in the `package.json` file. The most important changes are detailed below.

### Deployment Workflow Addition:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R42): Added a new GitHub Actions workflow named "Deploy to GitHub Pages." This workflow triggers on pushes to the `main` branch and includes steps for checking out the repository, setting up Node.js, installing dependencies with Yarn, building the project, creating a `CNAME` file, and deploying the build directory to GitHub Pages.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the project version from `0.11.1` to `0.11.2`.