### PR TITLE
fix: GitHub Action deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,16 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches: [main]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    needs: test # This ensures the CI workflow completes first
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
       - name: Checkout repository
@@ -39,4 +42,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          commit_message: "deploy: ${{ github.sha }} (${{ steps.package-version.outputs.version }}) via GitHub Pages" 
+          commit_message: "deploy: ${{ github.sha }} (${{ steps.package-version.outputs.version }}) via GitHub Pages"
+          clean: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to GitHub Pages. The changes aim to improve the workflow's reliability and ensure a clean deployment process.

Workflow improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L4-R13): Changed the trigger for the deployment workflow from `push` to `workflow_run`, making it dependent on the completion of the CI workflow. Added a conditional to ensure deployment only occurs if the CI workflow concludes successfully.

Deployment cleanup:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R46): Added the `clean: true` parameter to the deployment job to ensure the target directory is cleaned before publishing.